### PR TITLE
Fix get_author to handle list of authors according to spec

### DIFF
--- a/mangadex/api.py
+++ b/mangadex/api.py
@@ -417,7 +417,7 @@ class Api:
 
         url = f"{self.URL}/author"
         resp = URLRequest.request_url(url, "GET", timeout=self.timeout, params=kwargs)
-        return Author.author_from_dict(resp)
+        return list(Author.author_from_dict(author) for author in resp['data'])
 
     def get_author_by_id(self, author_id: str) -> Author:
         """

--- a/test/test_unittest.py
+++ b/test/test_unittest.py
@@ -88,11 +88,11 @@ class TestApi:
 
         url = f"{self.api.URL}/author/{author_id}"
 
-        raw_respone = md.URLRequest.request_url(
+        raw_response = md.URLRequest.request_url(
             url, "GET", timeout=self.timeout, params={"id": author_id}
         )
 
-        saved_resp = md.Author.author_from_dict(raw_respone)
+        saved_resp = md.Author.author_from_dict(raw_response)
 
         assert resp == saved_resp, "The Author Objects are not equal"
 

--- a/test/test_unittest.py
+++ b/test/test_unittest.py
@@ -96,6 +96,31 @@ class TestApi:
 
         assert resp == saved_resp, "The Author Objects are not equal"
 
+    def test_GetAuthorPlural(self):
+        author_ids = [
+            "df765fdc-ea9f-45d0-9191-d95615662d49",
+            "742bea86-c1ae-4893-bd06-805287991849",
+        ]
+
+        resp = self.api.get_author(ids=author_ids)
+
+        url = f"{self.api.URL}/author/?ids[]={author_ids[0]}&ids[]={author_ids[1]}"
+        raw_response = md.URLRequest.request_url(
+            url, "GET", timeout=self.timeout
+        )
+
+        manual_authors = [
+            md.Author.author_from_dict(author) for author in raw_response['data']
+        ]
+        manual_authors = dict((
+            (author.author_id, author) for author in manual_authors
+        ))
+
+        for author in author_ids:
+            api_author = next((a for a in resp if a.author_id == author), None)
+            assert api_author is not None, "Required author not returned in response"
+            assert api_author == manual_authors[author], "The Author Objects are not equal"
+
     def test_GetTags(self):
         resp = self.api.tag_list()
 


### PR DESCRIPTION
Small change, added test. 

Right now when the method is called it fails with this error:
```
models.py", line 301
if data["type"] != "author" or not data:
TypeError: list indices must be integers or slices, not str
```
due to `data` being a list. 

There might need to be better handling if there isn't `['data']` in resp. 

I noticed some tests have a superfluous `params` sent to `md.URLRequest.request_url` since the url is preformatted, but I didn't have the time to check and fix them. 

Also fixed a typoed variable name in a test. 
