### PR TITLE
Add missing dependency typing-extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    install_requires=["requests", "future", "python-dateutil", "pytest"],
+    install_requires=["requests", "future", "python-dateutil", "pytest", "typing-extensions"],
     source="https://github.com/EMACC99/mangadex",
     download_url="https://github.com/EMACC99/mangadex/releases",
     documentation="https://github.com/EMACC99/mangadex/wiki",


### PR DESCRIPTION
Add missed requirement used in `mangadex/errors.py`

Error shown in new venv if the requirement is missing:
```
Python 3.8.10 (default, Jun 22 2022, 20:18:18)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mangadex
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/mangadex/mangadex/__init__.py", line 1, in <module>
    from .errors import (
  File "/tmp/mangadex/mangadex/errors.py", line 6, in <module>
    from typing_extensions import Self
ModuleNotFoundError: No module named 'typing_extensions'
```