### PR TITLE
fix typo of copyright

### DIFF
--- a/mangadex/__init__.py
+++ b/mangadex/__init__.py
@@ -32,4 +32,4 @@ from .api import Api
 __author__ = "Eduardo Ceja"
 __version__ = "2.7"
 __license__ = "MIT"
-__copytight__ = "Copyright (c) 2021 Eduardo Ceja"
+__copyright__ = "Copyright (c) 2021 Eduardo Ceja"


### PR DESCRIPTION
noticed it in passing lol
__copyright__ in the init file was __copytight__