### PR TITLE
fix 'get_manga_volumes_and_chapters' api url

### DIFF
--- a/mangadex/series.py
+++ b/mangadex/series.py
@@ -173,7 +173,7 @@ class Chapter:
         params = None
         if "translatedLanguage" in kwargs:
             params = {"translatedLanguage[]": kwargs["translatedLanguage"]}
-        url = f"{self.api.url}/manga/{manga_id}/ aggregate"
+        url = f"{self.api.url}/manga/{manga_id}/aggregate"
         resp = URLRequest.request_url(
             url, "GET", timeout=self.api.timeout, params=params
         )


### PR DESCRIPTION
This pull request addresses an issue where the current URL for the route was resulting in a 404 error on the request. The fix has been implemented by adjusting the URL, ensuring that the route now works correctly without returning a 404 error.